### PR TITLE
fix: add required permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+# Add permissions for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add permissions block with contents: read, pages: write, and id-token: write
- Fixes 'Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable' error
- Required for actions/deploy-pages@v4 to work properly