### PR TITLE
fix: force dark theme to prevent invisible headings in light mode

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -68,4 +68,4 @@ analytics:
       id: 'G-CWRZLDKN40' # or "G-XXXXXXXXXX"
 
 ui:
-  theme: 'system' # Values: "system" | "light" | "dark" | "light:only" | "dark:only"
+  theme: 'dark:only' # Values: "system" | "light" | "dark" | "light:only" | "dark:only"


### PR DESCRIPTION
The pages force a dark palette locally, but the theme was set to 'system'. On a device in light mode, ApplyColorMode removed the .dark class from <html>, so --aw-color-text-default resolved to rgb(16 16 16).

The body carries the Tailwind utility class 'text-default', whose specificity (0,1,0) beats the 'body' element selector (0,0,1) used by each page to set color: var(--white). Headings without an explicit color (.section-title, problem card <h3>, ...) therefore inherited near-black on a dark background and became unreadable, while elements with an explicit color (--teal, --muted) stayed visible.

All 5 pages use Layout.astro, never LandingLayout, so showToggleTheme is never enabled and no theme switcher is affected.